### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,4 @@
+name        := "arm-intrinsics"
+description := "Built-in intrinsics for the ARM Advanced SIMD extension are available when the -mfpu=neon switch is used."
+website     := "https://developer.arm.com/documentation/den0018/a/NEON-Intrinsics/Introduction?lang=en"
+license     := "GPL-3.0"


### PR DESCRIPTION
Introduce `Library.uk`

This new file represents the first step towards proper versioning support of
external microlibrary in Unikraft.  The file itself acts as mechanism for
holding metadata-only values about the microlibrary.  This metadata is designed
to be compatible with GNU Make whilst simultaneously being human-readable and
readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions.
In a later step, once relevant integrations have been made to Unikrat's core
build system and to relevant tools such as KraftKit, the user will be able to
see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk,
Config.uk, but also includes new information such as SPDX License identifier.

Signed-off-by: Alexander Jung <alex@unikraft.io>
